### PR TITLE
Multiple code improvements - squid:S1213, squid:S1068, squid:RedundantThrowsDeclarationCheck

### DIFF
--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/auth/TenacityAuthenticator.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/auth/TenacityAuthenticator.java
@@ -9,17 +9,17 @@ import io.dropwizard.auth.Authenticator;
 import java.security.Principal;
 
 public class TenacityAuthenticator<C, P extends Principal> implements Authenticator<C, P> {
-    public static <C, P extends Principal> Authenticator<C, P> wrap(Authenticator<C, P> authenticator,
-                                                  TenacityPropertyKey tenacityPropertyKey) {
-        return new TenacityAuthenticator<>(authenticator, tenacityPropertyKey);
-    }
-
     private final Authenticator<C, P> underlying;
     private final TenacityPropertyKey tenacityPropertyKey;
 
     private TenacityAuthenticator(Authenticator<C, P> underlying, TenacityPropertyKey tenacityPropertyKey) {
         this.underlying = underlying;
         this.tenacityPropertyKey = tenacityPropertyKey;
+    }
+
+    public static <C, P extends Principal> Authenticator<C, P> wrap(Authenticator<C, P> authenticator,
+            TenacityPropertyKey tenacityPropertyKey) {
+        return new TenacityAuthenticator<>(authenticator, tenacityPropertyKey);
     }
 
     @Override

--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/core/CircuitBreaker.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/core/CircuitBreaker.java
@@ -37,7 +37,7 @@ public class CircuitBreaker {
         }
 
         @Override
-        public CircuitBreaker deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        public CircuitBreaker deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             final ObjectNode objectNode = p.readValueAsTree();
             final TenacityPropertyKey key  = keyFactory.from(objectNode.get("id").asText());
             return new CircuitBreaker(key, State.valueOf(objectNode.get("state").asText().toUpperCase()));

--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/servlets/TenacityCircuitBreakersServlet.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/servlets/TenacityCircuitBreakersServlet.java
@@ -19,7 +19,6 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 public class TenacityCircuitBreakersServlet extends TenacityServlet {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TenacityCircuitBreakersServlet.class);
     private static final long serialVersionUID = 0;
     private transient final TenacityCircuitBreakersResource circuitBreakersResource;
     private final Pattern byName = Pattern.compile("^/[\\d\\w\\s]*$");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1068 - Unused private fields should be removed.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
Please let me know if you have any questions.
George Kankava