### PR TITLE
squid:S00119 - Type parameter names should comply with a naming convention

### DIFF
--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/TenacityCommand.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/TenacityCommand.java
@@ -6,7 +6,7 @@ import com.netflix.hystrix.metric.consumer.RollingCommandEventCounterStream;
 import com.netflix.hystrix.strategy.properties.HystrixPropertiesFactory;
 import com.yammer.tenacity.core.properties.TenacityPropertyKey;
 
-public abstract class TenacityCommand<ReturnType> extends HystrixCommand<ReturnType> {
+public abstract class TenacityCommand<R> extends HystrixCommand<R> {
     protected TenacityCommand(TenacityPropertyKey tenacityPropertyKey) {
         super(HystrixCommand.Setter.withGroupKey(tenacityGroupKey())
                 .andCommandKey(tenacityPropertyKey)
@@ -70,5 +70,5 @@ public abstract class TenacityCommand<ReturnType> extends HystrixCommand<ReturnT
     }
 
     @Override
-    protected abstract ReturnType run() throws Exception;
+    protected abstract R run() throws Exception;
 }

--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/TenacityObservableCommand.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/TenacityObservableCommand.java
@@ -7,7 +7,7 @@ import com.netflix.hystrix.strategy.properties.HystrixPropertiesFactory;
 import com.yammer.tenacity.core.properties.TenacityPropertyKey;
 import rx.Observable;
 
-public abstract class TenacityObservableCommand<ReturnType> extends HystrixObservableCommand<ReturnType> {
+public abstract class TenacityObservableCommand<R> extends HystrixObservableCommand<R> {
     protected TenacityObservableCommand(TenacityPropertyKey tenacityPropertyKey) {
         super(HystrixObservableCommand.Setter.withGroupKey(TenacityCommand.tenacityGroupKey())
                 .andCommandKey(tenacityPropertyKey));
@@ -66,5 +66,5 @@ public abstract class TenacityObservableCommand<ReturnType> extends HystrixObser
     }
 
     @Override
-    protected abstract Observable<ReturnType> construct();
+    protected abstract Observable<R> construct();
 }

--- a/tenacity-core/src/main/java/com/yammer/tenacity/core/core/TenacityObservables.java
+++ b/tenacity-core/src/main/java/com/yammer/tenacity/core/core/TenacityObservables.java
@@ -6,26 +6,26 @@ import rx.Observable;
 public class TenacityObservables {
     private TenacityObservables() {}
 
-    public static <ReturnType> ReturnType execute(Observable<ReturnType> primary,
-                                                  Observable<ReturnType> secondary) {
+    public static <R> R execute(Observable<R> primary,
+                                                  Observable<R> secondary) {
         return primary
                 .onErrorResumeNext(secondary)
                 .toBlocking()
                 .single();
     }
 
-    public static <ReturnType> ReturnType execute(HystrixObservable<ReturnType> primary,
-                                                  HystrixObservable<ReturnType> secondary) {
+    public static <R> R execute(HystrixObservable<R> primary,
+                                                  HystrixObservable<R> secondary) {
         return execute(primary.observe(), secondary.toObservable());
     }
 
-    public static <ReturnType> ReturnType execute(Observable<ReturnType> primary,
-                                                  HystrixObservable<ReturnType> secondary) {
+    public static <R> R execute(Observable<R> primary,
+                                                  HystrixObservable<R> secondary) {
         return execute(primary, secondary.toObservable());
     }
 
-    public static <ReturnType> ReturnType execute(HystrixObservable<ReturnType> primary,
-                                                  Observable<ReturnType> secondary) {
+    public static <R> R execute(HystrixObservable<R> primary,
+                                                  Observable<R> secondary) {
         return execute(primary.observe(), secondary);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00119 - Type parameter names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00119
Please let me know if you have any questions.
George Kankava